### PR TITLE
Multithreading

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(jetpeer_all VERSION 3.0.2 LANGUAGES CXX)
+project(jetpeer_all VERSION 3.0.3 LANGUAGES CXX)
 
 include(FetchContent)
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -40,7 +40,7 @@ set_property(TARGET jetpeer APPEND PROPERTY PUBLIC_HEADER
 # Synchronous peer is a shell around the asynchronous peer
 # Programs using the Synchronous peer, have also to link the asynch peer
 # It also requires multithreading
-target_link_libraries(jetpeer INTERFACE jetpeerasync ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(jetpeer INTERFACE jetpeerasync Threads::Threads)
 
 
 include(GNUInstallDirs)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -2,6 +2,8 @@ project(jetpeer LANGUAGES CXX VERSION "${jetpeer_all_VERSION_MAJOR}.${jetpeer_al
 
 set( INTERFACE_INCLUDE_DIR ../include/jet)
 
+find_package(Threads)
+
 ####### libjetpeerasync
 set( PEERASYNC_INTERFACE_HEADERS
   ${INTERFACE_INCLUDE_DIR}/peerasync.hpp
@@ -37,7 +39,8 @@ set_property(TARGET jetpeer APPEND PROPERTY PUBLIC_HEADER
 
 # Synchronous peer is a shell around the asynchronous peer
 # Programs using the Synchronous peer, have also to link the asynch peer
-target_link_libraries(jetpeer INTERFACE jetpeerasync)
+# It also requires multithreading
+target_link_libraries(jetpeer INTERFACE jetpeerasync ${CMAKE_THREAD_LIBS_INIT})
 
 
 include(GNUInstallDirs)


### PR DESCRIPTION
Since synchronous jetpeer requires multithreading, the required library should be required by the interface.