### PR TITLE
Expose number of open requests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(jetpeer_all VERSION 3.0.6 LANGUAGES CXX)
+project(jetpeer_all VERSION 3.1.0 LANGUAGES CXX)
 
 include(FetchContent)
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,6 @@
 # Changelog for c++ jet peer
+## v3.1.0
+- Add new method openRequestCount(). It returns the number of requests waiting for a response.
 
 ## v2.0.0
 - Initial version, copied from internal version jet 2.0.11

--- a/include/jet/peerasync.hpp
+++ b/include/jet/peerasync.hpp
@@ -258,6 +258,8 @@ namespace hbk
 			/// \return -1: error, 0: nothing to be read
 			int receive();
 
+			/// \return Number of responses we are waiting for (open transactions)
+			size_t openRequestCount() const;
 
 		protected:
 			/// the path of the method is the key.

--- a/lib/asyncrequest.h
+++ b/lib/asyncrequest.h
@@ -63,6 +63,12 @@ namespace hbk
 			/// find the request this reply belongs to!
 			static void handleResult(const Json::Value& params);
 
+			/// \return Number of responses we are waiting for (open transactions)
+			static size_t openRequestCount()
+			{
+				return m_openRequestCbs.size();
+			}
+
 			/// Clear all open requests. Responses for those won't be recognized afterwards!
 			/// All request callbacks will be called with an error object stating that the request was canceled without response!
 			/// \return number of requests removed

--- a/lib/peerasync.cpp
+++ b/lib/peerasync.cpp
@@ -170,6 +170,12 @@ namespace hbk {
 			}
 		}
 
+		size_t PeerAsync::openRequestCount() const
+		{
+			return AsyncRequest::openRequestCount();
+		}
+
+
 		void PeerAsync::stop()
 		{
 			syslog(LOG_DEBUG, "jet peer '%s' %s:%u: Stopping...", m_name.c_str(), m_address.c_str(), m_port);


### PR DESCRIPTION
Add new method openRequestCount(). It returns the number of requests waiting for a response.

 Since a new method is added, version increases from v3.0.x to v3.1.0